### PR TITLE
HADOOP-19018. Release Hadoop 3.4.0.

### DIFF
--- a/src/releases/release-info-3.4.0.properties
+++ b/src/releases/release-info-3.4.0.properties
@@ -16,18 +16,18 @@
 
 # property file for 3.4.0
 hadoop.version=3.4.0
-rc=RC2
+rc=RC3
 previous.version=3.3.6
 release.branch=3.4
-git.commit.id=88fbe62f27e
+git.commit.id=bd8b77f398f
 
 jira.id=HADOOP-19018
 jira.title=Release 3.4.0
 
-amd.src.dir=https://dist.apache.org/repos/dist/dev/hadoop/hadoop-3.4.0-RC2
+amd.src.dir=https://dist.apache.org/repos/dist/dev/hadoop/hadoop-3.4.0-RC3
 arm.src.dir=${amd.src.dir}
 http.source=${amd.src.dir}
-asf.staging.url=https://repository.apache.org/content/repositories/orgapachehadoop-1402
+asf.staging.url=https://repository.apache.org/content/repositories/orgapachehadoop-1408
 
 cloudstore.profile=sdk2
 


### PR DESCRIPTION

JIRA: HADOOP-19018. Release Hadoop 3.4.0.

Prepare for Hadoop-3.4.0-RC3, Update validation.