### PR TITLE
HADOOP-19160. hadoop-auth should not depend on kerb-simplekdc

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -361,6 +361,7 @@
     <forbidden artifact="protobuf-java:jar:2.5.0"/>
     <forbidden artifact="slf4j-log4j12"/>
     <forbidden artifact="log4j12"/>
+    <forbidden artifact="kerb-simplekdc"/>
     <!-- not probed for as maven pulls them in from zk, somehow -->
 <!--    <forbidden artifact="logback-classic"/>-->
 <!--    <forbidden artifact="logback-core"/>-->


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `kerb-simplekdc` as forbidden artifact.  See https://github.com/apache/hadoop/pull/6788 for details.

https://issues.apache.org/jira/browse/HADOOP-19160