### PR TITLE
Add RC<N> suffix to release VOTE mail title

### DIFF
--- a/src/text/vote.txt
+++ b/src/text/vote.txt
@@ -1,4 +1,4 @@
-[VOTE] Release Apache Hadoop ${hadoop.version}
+[VOTE] Release Apache Hadoop ${hadoop.version} ${rc}
 
 Apache Hadoop ${hadoop.version}
 


### PR DESCRIPTION
Mail archive systems generally use the title to aggregate the threads. We should keep each RC having a dedicated thread to avoid confusion.

Bad examples:

https://lists.apache.org/thread/npwwpj45wnt804xmoqgth0s6fhydhxfb

https://www.mail-archive.com/common-dev@hadoop.apache.org/msg44642.html